### PR TITLE
chore: allow for overriding java version

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -4,6 +4,11 @@ name: ci-gradle
 on:
   workflow_call:
     inputs:
+      java_version:
+        description: What version of Java to use
+        type: number
+        default: 17
+        required: false
       publish_tests:
         description: Whether to attempt publishing unit test results.
         type: boolean
@@ -33,7 +38,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{ inputs.java_version }}
       - uses: google-github-actions/auth@v0
         if: inputs.setup_google_cloud_auth
         with:


### PR DESCRIPTION
`moderne-keycloak` still requires java version 11 because of gradle 6 because of other reasons