### PR TITLE
Add -Dorg.gradle.console=rich for colorized output

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -44,7 +44,7 @@ jobs:
       - name: build
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: ${{ env.GRADLE_SWITCHES }} -Dorg.gradle.project.ast.publish.username=${{ secrets.AST_PUBLISH_USERNAME }} -Dorg.gradle.project.ast.publish.password=${{ secrets.AST_PUBLISH_PASSWORD }} build
+          arguments: ${{ env.GRADLE_SWITCHES }} -Dorg.gradle.project.ast.publish.username=${{ secrets.AST_PUBLISH_USERNAME }} -Dorg.gradle.project.ast.publish.password=${{ secrets.AST_PUBLISH_PASSWORD }} -Dorg.gradle.console=rich build
       - name: publish-ast
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
As per https://docs.gradle.org/current/userguide/command_line_interface.html#sec:rich_console GitHub Actions supports colorized output; not 100% sure of any other rich output Gradle might produce, but there's only one way to tell.