### PR TITLE
Update to .ci-gradle to enrich dependabot

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -22,7 +22,8 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --warning-mode=all
-
+permissions: # The Dependency Submission API requires write permission
+  contents: write
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,6 +42,8 @@ jobs:
           credentials_json: ${{ secrets.GCR_KEY }}
       - uses: google-github-actions/setup-gcloud@v1.1.0
         if: inputs.setup_google_cloud_auth
+      - name: Run snapshot action
+        uses: mikepenz/gradle-dependency-submission@{latest}
       - name: build
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v1.1.0
         if: inputs.setup_google_cloud_auth
       - name: Run snapshot action
-        uses: mikepenz/gradle-dependency-submission@{latest}
+        uses: mikepenz/gradle-dependency-submission@v0.8.4
       - name: build
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
This patch is adding the action to create a dependency graph in dependabot and get PRs from the public Maven repository (openrewrite) without disrupting the current project status.