### PR TITLE
Revert "Update to .ci-gradle to enrich dependabot (#50)"

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -22,8 +22,7 @@ on:
 
 env:
   GRADLE_SWITCHES: --console=plain --info --warning-mode=all
-permissions: # The Dependency Submission API requires write permission
-  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -42,8 +41,6 @@ jobs:
           credentials_json: ${{ secrets.GCR_KEY }}
       - uses: google-github-actions/setup-gcloud@v1.1.0
         if: inputs.setup_google_cloud_auth
-      - name: Run snapshot action
-        uses: mikepenz/gradle-dependency-submission@v0.8.4
       - name: build
         uses: gradle/gradle-build-action@v2
         with:


### PR DESCRIPTION
This breaks moderne-ast-write.