### PR TITLE
Create releases for tags after publish

### DIFF
--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -64,3 +64,13 @@ jobs:
           slack-message: ":boom: Unable to build an artifact for ${{ github.repository }}\n${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_MEESEEKS_BOT_TOKEN }}
+      - name: Create release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          export tag=$(git describe --tags --abbrev=0)
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${tag#v}" \
+              --generate-notes


### PR DESCRIPTION
Figured this might be a nice extension to the existing release flow, although of course I've not been able to test this yet.

We _might_ need the following still to be allowed to create releases.
```yaml
permissions:
  contents: write
```