### PR TITLE
Notify on cancelled() too

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -83,7 +83,7 @@ jobs:
           files: ./**/build/test-results/**/TEST-*.xml
 
       - name: slackNotificationOfFailure
-        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         continue-on-error: true
         env:


### PR DESCRIPTION
**What**:
Adding Slack notifications for cancelled jobs too (e.g. because of a timeout).

**Why**:
For us not to miss some problems.