### PR TITLE
remove `release_scope` required/unused input

### DIFF
--- a/.github/workflows/publish-containerized-snapshot.yml
+++ b/.github/workflows/publish-containerized-snapshot.yml
@@ -9,11 +9,6 @@ on:
         type: number
         default: 17
         required: false
-      release_scope:
-        description: Git tagging release scope, such as major, minor, or patch.
-        type: string
-        required: true
-        default: minor
       runner:
         description: Which runner to use
         default: ubuntu-latest


### PR DESCRIPTION
[Invalid workflow file: .github/workflows/publish-dev.yml#L18](https://github.com/moderneinc/moderne-audit/actions/runs/17204929802/workflow)
The workflow is not valid. .github/workflows/publish-dev.yml (Line: 18, Col: 11): Input release_scope is required, but not provided while calling.

---
This input is unused (we are not releasing) but is set to be required failing the trigger