### PR TITLE
Use code-suggester fork to not post summary content

### DIFF
--- a/.github/workflows/pr-post-suggestions.yml
+++ b/.github/workflows/pr-post-suggestions.yml
@@ -44,7 +44,7 @@ jobs:
           rm pr_number.txt
 
       # Post suggestions as a comment on the PR
-      - uses: googleapis/code-suggester@v4
+      - uses: moderneinc/googleapis-code-suggester@v4-moderne
         with:
           command: review
           pull_number: ${{ env.PR_NUMBER }}


### PR DESCRIPTION
Based on https://github.com/googleapis/code-suggester/compare/main...moderneinc:googleapis-code-suggester:v4-moderne