### PR TITLE
Only notify for failures, not for cancellations

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -98,7 +98,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: slackNotificationOfFailure
-        if: (failure() || cancelled()) && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
+        if: failure() && github.event_name == 'schedule' && (github.repository_owner == 'openrewrite' || github.repository_owner == 'moderneinc')
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
         continue-on-error: true
         env:


### PR DESCRIPTION
Removed 'cancelled()' condition from slack notification trigger.