### PR TITLE
gradle/actions/wrapper-validation to v6

### DIFF
--- a/.github/workflows/ci-gradle-nexus.yml
+++ b/.github/workflows/ci-gradle-nexus.yml
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v6
       ########################
       # The biggest divergence point is choosing between actions/setup-java or graalvm
       - uses: actions/setup-java@v5

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           git config --global user.name "$(git --no-pager log --format=format:'%an' -n 1)"
           git config --global user.email "$(git --no-pager log --format=format:'%ae' -n 1)"
-      - uses: gradle/actions/wrapper-validation@v4
+      - uses: gradle/actions/wrapper-validation@v6
       - uses: actions/setup-java@v5
         with:
           distribution: temurin


### PR DESCRIPTION
Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.github.ChangeActionVersion?organizationId=QUxML01vZGVybmUgKyBPcGVuUmV3cml0ZQ%3D%3D#defaults=W3sidmFsdWUiOiJncmFkbGUvYWN0aW9ucy93cmFwcGVyLXZhbGlkYXRpb24iLCJuYW1lIjoiYWN0aW9uIn0seyJ2YWx1ZSI6InY2IiwibmFtZSI6InZlcnNpb24ifV0=

**What**:
Upgrade the gradle/actions/wrapper-validation to latest `v6`.

**Why**:
Get rid of the warning in GitHub Actions:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: gradle/actions/wrapper-validation@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://***.blog/changelog/2025-09-19-deprecation-of-node-20-on-***-actions-runners/
```