### PR TITLE
Drop `build_on_graal` parameter from `ci-gradle-nexus.yml`

### DIFF
--- a/.github/workflows/ci-gradle-nexus.yml
+++ b/.github/workflows/ci-gradle-nexus.yml
@@ -14,16 +14,6 @@ on:
         type: boolean
         default: true
         required: false
-      build_on_graal:
-        description: Whether to perform the main build and test operation on graalvm. When false, the workflow will use actions/setup-java.
-        type: boolean
-        required: false
-        default: false
-      install_graal_languages:
-        description: Single string of space-separated graal languages to install when "build_on_graal" is true. For example, "nodejs python ruby R llvm-toolchain"
-        type: string
-        required: false
-        default: ""
     secrets:
       gradle_enterprise_access_key:
         description: Value of the Gradle Enterprise access token to use.
@@ -73,24 +63,10 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gradle/actions/wrapper-validation@v6
-      ########################
-      # The biggest divergence point is choosing between actions/setup-java or graalvm
       - uses: actions/setup-java@v5
-        if: (!(inputs.build_on_graal))
         with:
           distribution: temurin
           java-version: 21
-      ###
-      - uses: DeLaGuardo/setup-graalvm@5.0
-        if: inputs.build_on_graal
-        with:
-          java: java11
-          graalvm: 21.2.0
-      - name: install-polyglot-languages
-        if: inputs.build_on_graal && inputs.install_graal_languages != ''
-        run: gu install ${{ inputs.install_graal_languages }}
-      ########################
-
       - name: setup gradle
         uses: gradle/actions/setup-gradle@v5
       - name: build


### PR DESCRIPTION
**What**:
Removing support for `build_on_graal` and `install_graal_languages` parameters.

**Why**:

I am not fully sure we can remove, but everything says yes:
- the `ci-gradle-nexus.yml` seems to be used only by a single project: https://github.com/moderneinc/rewrite-cobol and it doesn't specify these flags
- the parameters were added in 2023 and has received little edits (other than mass changes), so it's another signal it's not actively used

The reason I am not fully sure is that GitHub search only traverses the default (main) branches. So there's some risk the flags are used in some non-default branches for something meaningful. But I am not aware of us having meaningful CI hidden in branches.

Also the `DeLaGuardo/setup-graalvm` action used underneath is no longer maintained.
So I suggest to clean it up. Worst case we'll have to revert it.