### PR TITLE
Create a GitHub release for the tag cut by publish-maven-artifact

### DIFF
--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -66,3 +66,13 @@ jobs:
           git config --local user.name "github-actions[bot]"
       - name: build, test, and publish jar
         run: ./gradlew ${GRADLE_SWITCHES} ${GRGIT_AUTH_SWITCHES} -Prelease.scope=${{ inputs.release_scope }} final
+      - name: create-github-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.caller_github_token }}
+        run: |
+          tag=$(git describe --tags --abbrev=0)
+          gh release create "$tag" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${tag#v}" \
+              --verify-tag \
+              --generate-notes


### PR DESCRIPTION
`publish-maven-artifact.yml` cuts a git tag via nebula `final`, but never creates a GitHub release for it. All 10 consumer repos therefore have a long list of tags and zero releases.

This adds a `create-github-release` step mirroring the one already in `publish-containerized-gradle-app.yml`:

https://github.com/moderneinc/gh-automation/blob/fbf80f70c792a969855e1496433d4c1262b62f3f/.github/workflows/publish-containerized-gradle-app.yml#L85-L94

so the behaviour is consistent across the two publishing workflows.

### Affected repos

All 10 pin `@main`, so this takes effect on their next `Release` run with no per-repo change. All use `v`-prefixed semver tags, so `--title="${tag#v}"` applies cleanly to every one.

| Repo | Latest tag | Releases today |
|---|---|---|
| [moderne-agent-model](https://github.com/moderneinc/moderne-agent-model/blob/main/.github/workflows/release.yml) | v0.262.0 | 0 |
| [moderne-artifact-model](https://github.com/moderneinc/moderne-artifact-model/blob/main/.github/workflows/release.yml) | v0.132.0 | 0 |
| [moderne-build-logic](https://github.com/moderneinc/moderne-build-logic/blob/main/.github/workflows/release.yml) | v0.174.0 | 0 |
| [moderne-cloud-common](https://github.com/moderneinc/moderne-cloud-common/blob/main/.github/workflows/release.yml) | v0.12.0 | 0 |
| [moderne-common](https://github.com/moderneinc/moderne-common/blob/main/.github/workflows/release.yml) | v0.411.0 | 0 |
| [moderne-lstcrypto](https://github.com/moderneinc/moderne-lstcrypto/blob/main/.github/workflows/release.yml) | v0.1.0 | 0 |
| [moderne-model](https://github.com/moderneinc/moderne-model/blob/main/.github/workflows/release.yml) | v0.26.0 | 0 |
| [moderne-organizations-model](https://github.com/moderneinc/moderne-organizations-model/blob/main/.github/workflows/release.yml) | v0.17.0 | 0 |
| [moderne-recipes](https://github.com/moderneinc/moderne-recipes/blob/main/.github/workflows/release.yml) | v0.1.1 | 0 |
| [moderne-worker-model](https://github.com/moderneinc/moderne-worker-model/blob/main/.github/workflows/release.yml) | v0.330.0 | 0 |

### Why here and not a tag-triggered workflow in each repo

The obvious alternative — a per-repo `on: push: tags` workflow, [as apache/camel-upgrade-recipes does](https://github.com/apache/camel-upgrade-recipes/blob/main/.github/workflows/github-release.yml) — would never fire. The tag is pushed with `caller_github_token` (`secrets.GITHUB_TOKEN`), and [GitHub does not trigger workflow runs from events created with `GITHUB_TOKEN`](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/trigger-a-workflow#triggering-a-workflow-from-a-workflow). Doing it inline in the job that cuts the tag sidesteps that entirely, and fixes all consumers at once.

### Notes

- No `permissions:` block added on purpose. The job already pushes tags with this same token, so `contents: write` is necessarily present; adding an explicit block would hard-fail any caller whose token is more restrictive rather than degrade.
- `--verify-tag` fails loudly rather than creating a release for a tag that doesn't exist. The step runs last, so a failure surfaces as a red run over an already-successful publish.
- [`publish-maven-central.yml`](https://github.com/moderneinc/gh-automation/blob/fbf80f70c792a969855e1496433d4c1262b62f3f/.github/workflows/publish-maven-central.yml) is deliberately untouched — it runs off an already-pushed tag (`release.useLastTag=true`) and is a different flow.
- Not backfilled: existing tags stay release-less. Only future releases are affected.