### PR TITLE
Forward Code Genome Project artifact credentials to Gradle builds

### DIFF
--- a/.github/workflows/ci-gradle-nexus.yml
+++ b/.github/workflows/ci-gradle-nexus.yml
@@ -44,6 +44,12 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -54,6 +60,11 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty on fork
+  # pull requests, where GitHub withholds secrets; the repository declaration is guarded on both
+  # values being set, so external contributor builds keep resolving as they do today.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle-nexus.yml
+++ b/.github/workflows/ci-gradle-nexus.yml
@@ -60,9 +60,6 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty on fork
-  # pull requests, where GitHub withholds secrets; the repository declaration is guarded on both
-  # values being set, so external contributor builds keep resolving as they do today.
   ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
   ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -41,6 +41,12 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
       OPS_GITHUB_ACTIONS_WEBHOOK:
         required: false
 
@@ -53,6 +59,11 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty on fork
+  # pull requests, where GitHub withholds secrets; the repository declaration is guarded on both
+  # values being set, so external contributor builds keep resolving as they do today.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -59,9 +59,6 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. Empty on fork
-  # pull requests, where GitHub withholds secrets; the repository declaration is guarded on both
-  # values being set, so external contributor builds keep resolving as they do today.
   ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
   ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 

--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -69,6 +69,8 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} -Prelease.scope=${{ inputs.release_scope }} final -x test
 
 

--- a/.github/workflows/publish-containerized-snapshot.yml
+++ b/.github/workflows/publish-containerized-snapshot.yml
@@ -64,4 +64,6 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} dockerBuildImage dockerPushImageAmazon -x test

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -50,8 +50,6 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. The repository
-  # declaration is guarded on both values being set, so builds without them resolve as they do today.
   ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
   ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -35,6 +35,12 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
 
 env:
   GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
@@ -44,6 +50,10 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. The repository
+  # declaration is guarded on both values being set, so builds without them resolve as they do today.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -59,8 +59,6 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. The repository
-  # declaration is guarded on both values being set, so builds without them resolve as they do today.
   ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
   ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 

--- a/.github/workflows/publish-maven-central.yml
+++ b/.github/workflows/publish-maven-central.yml
@@ -39,6 +39,12 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
+      cgp_artifacts_maven_username:
+        description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
 
 env:
   GRADLE_SWITCHES: --console=plain --info --stacktrace --warning-mode=all --no-daemon
@@ -53,6 +59,10 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
+  # Resolve org.openrewrite and io.moderne dependencies from the Code Genome Project. The repository
+  # declaration is guarded on both values being set, so builds without them resolve as they do today.
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:


### PR DESCRIPTION
Counterpart to [openrewrite/rewrite-build-gradle-plugin#201](https://github.com/openrewrite/rewrite-build-gradle-plugin/pull/201) and the equivalent change already made in `openrewrite/gh-automation`, so that **moderneinc** builds can resolve `org.openrewrite` and `io.moderne` artifacts from `https://artifacts.codegenomeproject.org/maven`.

CGP is now the first publish target for both our snapshots and releases, so builds need to resolve from it ahead of every other remote source. `artifactory.moderne.ninja/moderne-cache-3` deliberately does not proxy CGP — it is unauthenticated so that external contributor CI runs work — so CGP has to be declared as its own credentialed repository.

## What this does

Declares two optional `workflow_call` secrets and maps them to the Gradle properties the convention plugin reads:

```yaml
ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
```

Property names match the OpenRewrite side exactly, so the same secrets and env work across both orgs.

Applied to every workflow that runs a Gradle build resolving dependencies:

- `ci-gradle.yml`
- `ci-gradle-nexus.yml`
- `publish-maven-artifact.yml`
- `publish-maven-central.yml`
- `publish-containerized-gradle-app.yml` (step-level env; no `secrets:` block, relies on `secrets: inherit`)
- `publish-containerized-snapshot.yml` (same)

## Deliberately skipped

`pr-run-recipes.yml`. It carries an explicit comment that it receives untrusted pull request code and should not have secrets in its environment. Adding another credential there is the wrong direction; if those runs ever need CGP artifacts we should solve it separately.

## Rollout notes

`CGP_ARTIFACTS_MAVEN_USERNAME` and `CGP_ARTIFACTS_MAVEN_TOKEN` already exist as moderneinc org secrets scoped to all repositories, and callers use `secrets: inherit` — so this is **not** inert on merge. It takes effect for a given repo once that repo also picks up the matching `io.moderne.gradle.java-base` convention plugin change (moderne-build-logic, separate PR), which declares the CGP repository ahead of Sonatype snapshots, the Artifactory cache and Maven Central, scoped to the `org.openrewrite` and `io.moderne` groups, and only when both properties are non-empty.

Fork pull requests do not receive secrets, so the values are empty there and the guard keeps external contributor builds resolving exactly as they do today.

AWS credentials for *publishing* to CGP (`CGP_AWS_*`) are out of scope here, same as in the OpenRewrite PR.