### PR TITLE
Refresh dependencies on the Gradle release publish paths

### DIFF
--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -21,7 +21,7 @@ on:
         required: false
 
 env:
-  GRADLE_SWITCHES: --console=plain --info --stacktrace
+  GRADLE_SWITCHES: --console=plain --info --stacktrace --refresh-dependencies
 
 jobs:
   release:

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -44,7 +44,7 @@ on:
 
 env:
   GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
-  GRADLE_SWITCHES: "--console=plain --info --stacktrace --no-daemon"
+  GRADLE_SWITCHES: "--console=plain --info --stacktrace --no-daemon --refresh-dependencies"
   GRGIT_AUTH_SWITCHES: "-Dorg.ajoberstar.grgit.auth.username=${{github.actor}} -Dorg.ajoberstar.grgit.auth.password=${{secrets.caller_github_token}}"
   AST_PUBLISH_USERNAME: ${{ secrets.ast_publish_username }}
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}


### PR DESCRIPTION
Mirrors openrewrite/gh-automation#108, which fixes a release-reliability bug on the Gradle publish paths.

## The failure it prevents

The `rewrite-spring` v6.37.1 release publish [failed](https://github.com/openrewrite/rewrite-spring/actions/runs/32192538586) at `:signNebulaPublication`:

```
Cannot call Task.setEnabled(boolean) on task ':release' after task has started execution.
  at nebula.plugin.release.OverrideStrategies$ReleaseLastTagStrategy.selector(OverrideStrategies.groovy:63)
```

Not really a nebula bug — a *stale dependency resolution* bug in the workflow. The Gradle home cache restored from the previous CI run carried Gradle's dynamic-version resolutions, and `cacheDynamicVersionsFor` defaults to **24 hours**. The build plugin resolved to a version that had already been superseded by a fix hours earlier, and the release died. Wiping the repo's Actions caches by hand unblocked it; that was a one-off, so the openrewrite PR made it durable with `--refresh-dependencies`.

## Why this repo is exposed too

Same mechanism, confirmed on live consumers:

- `moderne-cloud-common/build.gradle`: `id("io.moderne.gradle.library") version "latest.integration"`
- `moderne-graphql-api/build.gradle`: `id "io.moderne.gradle.saas-service" version "latest.integration" apply false`

A dynamic version in the `plugins` block is exactly the case that gets pinned for 24 hours. `latest.integration` is the *worse* variant: openrewrite already needed `--refresh-dependencies` on its snapshot publish because a stale module-to-repository mapping made `latest.integration` resolve against Maven Central only, skipping the snapshot repo entirely.

Caching here comes from `actions/setup-java` with `cache: "gradle"` (and `setup-gradle` on the containerized workflows) rather than openrewrite's composite action, but it caches `~/.gradle/caches` just the same, with restore-key fallback across runs.

## Scope

Release publishes only.

| workflow | change | why |
|---|---|---|
| `publish-maven-artifact.yml` | added | `final` release publish — the direct analogue of the failure above |
| `publish-containerized-gradle-app.yml` | added | `final` release, ships an image to ECR |
| `publish-containerized-snapshot.yml` | none | runs as often as CI, so it would carry the most revalidation cost. Deliberately left cached to keep the dev path fast |
| `ci-gradle.yml` | none | build-only, publishes nothing. Staleness is a non-event, and refreshing on every push across every repo is the expensive case |
| `repository-backup.yml` | none | runs no Gradle, sets up no Gradle cache |

Note the residual exposure this leaves: a dev image published from `publish-containerized-snapshot.yml` can still be built against a resolution up to 24 hours stale. That is a deliberate speed-over-freshness call on the dev path, not an oversight — worth revisiting if a dev image ever ships surprisingly old code.

## Tradeoff

`--refresh-dependencies` invalidates cached metadata and dynamic-version resolutions but leaves the artifact cache intact, so most fetches become HTTP 304 revalidations rather than full redownloads. The alternative — disabling the Gradle cache on these jobs — also fixes the staleness but discards the artifacts, making every release redownload its whole dependency graph.

It does refresh *changing* modules too, so a release resolving anything snapshot-shaped picks up the newest snapshot at publish time rather than the copy CI validated. A release can therefore be cut against a slightly newer upstream state than the last green build saw. That is the correct bias for a release — and the failure above is what the opposite bias costs. There is also a modest wall-clock cost per release from re-checking metadata against every configured repository.

## Blast radius

Both workflows are consumed via `@main` (`moderne-cloud-common/release.yml`, `moderne-graphql-api/publish.yml`, and others), so this takes effect for every consuming repo the moment it merges. No staged rollout. That is the intent, and the downside is bounded to the revalidation cost above.

`actionlint` reports the same 5 pre-existing findings before and after; none are introduced here.
