### PR TITLE
Rename the Code Genome Project artifact secrets to CODEGENOME_USERNAME/TOKEN

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -36,11 +36,17 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
       OPS_GITHUB_ACTIONS_WEBHOOK:
         required: false
@@ -54,8 +60,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -69,8 +69,8 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} -Prelease.scope=${{ inputs.release_scope }} final -x test
 
 

--- a/.github/workflows/publish-containerized-snapshot.yml
+++ b/.github/workflows/publish-containerized-snapshot.yml
@@ -64,6 +64,6 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} dockerBuildImage dockerPushImageAmazon -x test

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -35,11 +35,17 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
 
 env:
@@ -50,8 +56,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:


### PR DESCRIPTION
- Matches openrewrite/gh-automation#109. Renames the `cgp_artifacts_maven_username`/`cgp_artifacts_maven_token` secrets to `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` across `ci-gradle`, `publish-maven-artifact`, `publish-containerized-gradle-app`, and `publish-containerized-snapshot`.

The old names remain declared as deprecated aliases in the two workflows that declare secrets, and every `ORG_GRADLE_PROJECT_codegenome*` binding falls back to them, so consumers can migrate at their own pace with no window where resolution breaks. The two containerized workflows declare no `secrets:` block and rely on `secrets: inherit`, so they only needed the fallback. Once every consumer is updated, `grep -rn cgp_artifacts_maven` finds the blocks to delete.