### PR TITLE
Drop the deprecated cgp_artifacts_maven_* secret aliases

### DIFF
--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -36,11 +36,17 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
       OPS_GITHUB_ACTIONS_WEBHOOK:
         required: false
@@ -54,8 +60,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   build:

--- a/.github/workflows/ci-gradle.yml
+++ b/.github/workflows/ci-gradle.yml
@@ -42,12 +42,6 @@ on:
       CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_username:
-        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
-        required: false
-      cgp_artifacts_maven_token:
-        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
-        required: false
       OPS_GITHUB_ACTIONS_WEBHOOK:
         required: false
 
@@ -60,8 +54,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
 
 jobs:
   build:

--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -69,8 +69,8 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} -Prelease.scope=${{ inputs.release_scope }} final -x test
 
 

--- a/.github/workflows/publish-containerized-gradle-app.yml
+++ b/.github/workflows/publish-containerized-gradle-app.yml
@@ -69,8 +69,8 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} -Prelease.scope=${{ inputs.release_scope }} final -x test
 
 

--- a/.github/workflows/publish-containerized-snapshot.yml
+++ b/.github/workflows/publish-containerized-snapshot.yml
@@ -64,6 +64,6 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} dockerBuildImage dockerPushImageAmazon -x test

--- a/.github/workflows/publish-containerized-snapshot.yml
+++ b/.github/workflows/publish-containerized-snapshot.yml
@@ -64,6 +64,6 @@ jobs:
           GRGIT_PASS: ${{ secrets.GITHUB_TOKEN }}
           MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
           MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+          ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+          ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
         run: ./gradlew ${{ env.GRADLE_SWITCHES }} dockerBuildImage dockerPushImageAmazon -x test

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -41,12 +41,6 @@ on:
       CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_username:
-        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
-        required: false
-      cgp_artifacts_maven_token:
-        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
-        required: false
 
 env:
   GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
@@ -56,8 +50,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN }}
 
 jobs:
   release:

--- a/.github/workflows/publish-maven-artifact.yml
+++ b/.github/workflows/publish-maven-artifact.yml
@@ -35,11 +35,17 @@ on:
       moderne_artifactory_password:
         description: Password for accessing the https://artifactory.moderne.ninja/artifactory/moderne-private repository.
         required: false
-      cgp_artifacts_maven_username:
+      CODEGENOME_USERNAME:
         description: Username for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
         required: false
-      cgp_artifacts_maven_token:
+      CODEGENOME_TOKEN:
         description: Token for artifacts.codegenomeproject.org, used to resolve org.openrewrite and io.moderne dependencies.
+        required: false
+      cgp_artifacts_maven_username:
+        description: Deprecated alias for CODEGENOME_USERNAME; drop once all callers have migrated.
+        required: false
+      cgp_artifacts_maven_token:
+        description: Deprecated alias for CODEGENOME_TOKEN; drop once all callers have migrated.
         required: false
 
 env:
@@ -50,8 +56,8 @@ env:
   AST_PUBLISH_PASSWORD: ${{ secrets.ast_publish_password }}
   MODERNE_ARTIFACTORY_USERNAME: ${{ secrets.moderne_artifactory_username }}
   MODERNE_ARTIFACTORY_PASSWORD: ${{ secrets.moderne_artifactory_password }}
-  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.cgp_artifacts_maven_username }}
-  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.cgp_artifacts_maven_token }}
+  ORG_GRADLE_PROJECT_codegenomeUsername: ${{ secrets.CODEGENOME_USERNAME || secrets.cgp_artifacts_maven_username }}
+  ORG_GRADLE_PROJECT_codegenomePassword: ${{ secrets.CODEGENOME_TOKEN || secrets.cgp_artifacts_maven_token }}
 
 jobs:
   release:


### PR DESCRIPTION
- Follow-up to #141, which renamed these secrets to `CODEGENOME_USERNAME`/`CODEGENOME_TOKEN` and kept `cgp_artifacts_maven_username`/`cgp_artifacts_maven_token` as deprecated aliases. This removes the aliases and the `||` fallbacks across `ci-gradle`, `publish-maven-artifact`, `publish-containerized-gradle-app`, and `publish-containerized-snapshot`.

- **Stacked on #141**, which is still open, so this targets `tim/codegenome-secret-rename` rather than `main` — GitHub will retarget it to `main` automatically once #141 merges. The equivalent change for the other repo is openrewrite/gh-automation#110.

**Draft on purpose — downstream consumers must be migrated first.** Any caller still passing the old names silently ends up with empty credentials rather than a build error: the recipe-repositories convention plugin just goes inert and dependency resolution falls back to Maven Central, so CI stays green while CGP-only artifacts quietly stop resolving. Before marking this ready, sweep the consuming repositories for `cgp_artifacts_maven` and confirm zero hits, then delete the old `CGP_ARTIFACTS_MAVEN_*` org secrets.